### PR TITLE
Rename handle functions for routing

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -17,6 +17,9 @@ export default function App() {
     setRoute('home')
   }
 
+  function handleNeedToRegister() {
+    setRoute('register')
+  }
   function handleRegister() {
     setRoute('home')
   }
@@ -65,7 +68,7 @@ export default function App() {
       <div className="App">
         <SignIn 
           handleSignIn={handleSignIn}
-          handleRegister={handleRegister}
+          handleNeedToRegister={handleNeedToRegister}
         />
       </div>
     )
@@ -74,7 +77,7 @@ export default function App() {
     return(
       <div className="App">
         <Registration 
-          handleSubmit={handleRegister}
+          handleRegister={handleRegister}
         />
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -18,7 +18,7 @@ export default function App() {
   }
 
   function handleRegister() {
-    setRoute('register')
+    setRoute('home')
   }
 
   function handleSignOut() {
@@ -74,7 +74,7 @@ export default function App() {
     return(
       <div className="App">
         <Registration 
-          handleSubmit={handleSubmit}
+          handleSubmit={handleRegister}
         />
       </div>
     )

--- a/src/App.js
+++ b/src/App.js
@@ -12,6 +12,7 @@ export default function App() {
   const [input, setInput] = useState('')
   const [box, setBox] = useState({})
   const [route, setRoute] = useState('signin')
+  // current route possibilites are signin, register, and home
 
   function handleSignIn() {
     setRoute('home')

--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ export default function App() {
   const [box, setBox] = useState({})
   const [route, setRoute] = useState('signin')
 
-  function handleSubmit() {
+  function handleSignIn() {
     setRoute('home')
   }
 
@@ -64,7 +64,7 @@ export default function App() {
     return (
       <div className="App">
         <SignIn 
-          handleSubmit={handleSubmit}
+          handleSignIn={handleSignIn}
           handleRegister={handleRegister}
         />
       </div>

--- a/src/components/Registration/Registration.js
+++ b/src/components/Registration/Registration.js
@@ -1,6 +1,6 @@
 import './Registration.css'
 
-export default function Registration({handleSubmit}) {
+export default function Registration({handleRegister}) {
     return (
         <>
             <form className="registration-form">
@@ -16,7 +16,7 @@ export default function Registration({handleSubmit}) {
                 </label>
                 <button 
                     type="submit"
-                    onClick={handleSubmit}>
+                    onClick={handleRegister}>
                     Register</button>
             </form>
         </>

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -1,6 +1,6 @@
 import './SignIn.css'
 
-export default function SignIn({handleSignIn, handleRegister}) {
+export default function SignIn({handleSignIn, handleNeedToRegister}) {
 
     return (
         <>
@@ -18,7 +18,7 @@ export default function SignIn({handleSignIn, handleRegister}) {
                     Sign In
                 </button>
                 <p 
-                    onClick={handleRegister}>
+                    onClick={handleNeedToRegister}>
                     Need to Register?
                 </p>
             </form>

--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -1,6 +1,6 @@
 import './SignIn.css'
 
-export default function SignIn({handleSubmit, handleRegister}) {
+export default function SignIn({handleSignIn, handleRegister}) {
 
     return (
         <>
@@ -14,7 +14,7 @@ export default function SignIn({handleSubmit, handleRegister}) {
                 </label>
                 <button 
                     type="submit"
-                    onClick={handleSubmit}>
+                    onClick={handleSignIn}>
                     Sign In
                 </button>
                 <p 


### PR DESCRIPTION
The handleSubmit function was being called on both the SignIn and Registration components.  Originally both actions just resulted in resetting the route to 'home'.  Now they will need to do different actions, so they need different names.  The new handle functions are

handleSignIn
handleNeedToRegister
handleRegister
handleSignOut

These just handle routing right now - changing to different screens.