### PR TITLE
FIX onSubmitSignIn()

### DIFF
--- a/src/components/SignIn/SignIn.js
+++ b/src/components/SignIn/SignIn.js
@@ -11,7 +11,8 @@ export default function SignIn({handleSignIn, handleNeedToRegister}) {
     function handleOnPasswordChange(event) {
         setPassword(event.target.value)
     }
-    function onSubmitSignIn() {
+    function onSubmitSignIn(event) {
+        event.preventDefault()
         fetch('http://localhost:3001/signin', { 
             method: 'post',
             headers: {'Content-Type': 'application/json'},
@@ -21,7 +22,11 @@ export default function SignIn({handleSignIn, handleNeedToRegister}) {
             })
         })
         .then(response => response.json())
-        .then(console.log)
+        .then(data => {
+            if(data === 'Success'){
+                handleSignIn()
+            }
+        })
         .catch(error => console.error(error))
     }
 


### PR DESCRIPTION
Add event.preventDefault() to onSubmitSignIn() to solve response error.  In Chrome, I was receiving a "Failed to load response data. No resource with given identifier found."  I think it ended up being a problem because there was a change in navigation before the response was read?  It currently works on Chrome, Safari, and Firefox.

Prior to this fix, I also checked the response for 'success' and changed route on success.